### PR TITLE
Update to angulillos 0.7.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ bucketSuffix  := "era7.com"
 javaVersion   := "1.8"
 
 libraryDependencies ++= Seq(
-  "bio4j"                   % "angulillos" % "0.7.0",
+  "bio4j"                   % "angulillos" % "0.7.2",
   "com.thinkaurelius.titan" % "titan-core" % "1.0.0"
 )
 

--- a/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
@@ -29,9 +29,15 @@ implements
 
   public TitanManagement managementSystem() { return titanGraph.openManagement(); }
 
+  /*
+    The transaction/Graph returned by this method is a thread-independent transaction; it can safely be used from different threads. See Titan transaction docs.
+  */
   @Override
   public ConcurrentTransaction beginTx() { return new ConcurrentTransaction( titanGraph.newTransaction() ); }
 
+  /*
+    This method will (try to) commit the implictly opened thread-local transaction.
+  */
   @Override
   public void commit() { titanGraph.tx().commit(); }
 
@@ -41,9 +47,15 @@ implements
   @Override
   public TitanUntypedGraph graph() { return this; }
 
+  /*
+    This method will (try to) rollback the implictly opened thread-local transaction.
+  */
   @Override
   public void rollback() { titanGraph.tx().rollback(); }
 
+  /*
+    This class wraps a global threadsafe Titan transaction; it is a TitanUntypedGraph too, as this is the Titan API design. See the Titan docs for details.
+  */
   public class ConcurrentTransaction extends TitanUntypedGraph {
 
     private final TitanTransaction rawTx;
@@ -56,13 +68,15 @@ implements
     @Override
     public final ConcurrentTransaction graph() { return this; }
 
+    /*
+      This two methods will work with *this* transaction, not the implicit one.
+    */
     @Override
     public final void commit() { rawTx.commit(); }
 
     @Override
     public void rollback() { rawTx.rollback(); }
   }
-
 
   @Override
   public TitanEdge addEdge(TitanVertex source, AnyEdgeType edgeType, TitanVertex target) {


### PR DESCRIPTION
The idea is to

1. titan untyped graph should be itself a transaction, corresponding to the implicit thread-local Titan variety
2. we have a subclass wrapping a thread-independent concurrent transaction