### PR TITLE
UntypedGraph, transactions, Autocloseable

### DIFF
--- a/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
@@ -16,7 +16,8 @@ import java.util.Optional;
 public class TitanUntypedGraph
 implements
   UntypedGraph.Transactional<TitanVertex, TitanEdge>,
-  UntypedGraph.Transaction<TitanVertex, TitanEdge>
+  UntypedGraph.Transaction<TitanVertex, TitanEdge>,
+  AutoCloseable
 {
 
   private final TitanGraph titanGraph;
@@ -43,6 +44,9 @@ implements
 
   @Override
   public void shutdown() { titanGraph.close(); }
+
+  @Override
+  public void close() { titanGraph.tx().close(); }
 
   @Override
   public TitanUntypedGraph graph() { return this; }

--- a/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
@@ -73,13 +73,14 @@ implements
     public final ConcurrentTransaction graph() { return this; }
 
     /*
-      This two methods will work with *this* transaction, not the implicit one.
+      All methods here will work with *this* transaction, not the implicit one.
     */
     @Override
-    public final void commit() { rawTx.commit(); }
-
+    public final void commit()    { rawTx.commit();   }
     @Override
-    public void rollback() { rawTx.rollback(); }
+    public final void rollback()  { rawTx.rollback(); }
+    @Override
+    public final void close()     { rawTx.close();    }
   }
 
   @Override


### PR DESCRIPTION
I think we could

- [x] make `TitanUntypedGraph` autocloseable, where `close()` is understood to close the corresponding thread-local transaction
- [ ] In `ConcurrentTransaction`, override `close()` to mean, naturally, closing this transaction

Note that closing here always means closing a transaction, *not* the graph! For that we have `shutdown()`.