### PR TITLE
Document runtime behavior of vertices

### DIFF
--- a/docs/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java.md
+++ b/docs/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java.md
@@ -195,7 +195,13 @@ All methods here will work with *this* transaction, not the implicit one.
         .vertices()
     );
   }
+```
 
+
+**IMPORTANT** note that in Titan 1.0.0 this method will iterate over **all** vertices and then *filter* those with label `vertexType._label()`.
+
+
+```java
   @Override
   public Stream<TitanVertex> vertices(AnyVertexType vertexType) {
 

--- a/docs/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java.md
+++ b/docs/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java.md
@@ -198,7 +198,9 @@ All methods here will work with *this* transaction, not the implicit one.
 ```
 
 
-**IMPORTANT** note that in Titan 1.0.0 this method will iterate over **all** vertices and then *filter* those with label `vertexType._label()`.
+**IMPORTANT** note that in Titan 1.0.0 this method will iterate over **all** vertices and then *filter* those with label `vertexType._label()`. For a discussion see
+
+- [Titan users post](https://groups.google.com/forum/#!topic/aureliusgraphs/f2HX9hUvBuA)
 
 
 ```java

--- a/docs/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraphSchema.java.md
+++ b/docs/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraphSchema.java.md
@@ -12,9 +12,6 @@ import com.thinkaurelius.titan.core.schema.*;
 
 public class TitanUntypedGraphSchema
 implements UntypedGraphSchema<TitanManagement> {
-
-  // TODO: create if not exists?
-
 ```
 
 This method should take into account vertex label
@@ -23,7 +20,6 @@ This method should take into account vertex label
   public TitanManagement createVertexType(TitanManagement titanManagement, AnyVertexType vertexType) {
     titanManagement
       .makeVertexLabel(vertexType._label())
-      // .setStatic() ?
       .make();
     return titanManagement;
   }
@@ -132,9 +128,6 @@ This method should take into account property's element type and from-arity
 
     return titanManagement;
   }
-
-
-
 }
 
 ```

--- a/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
@@ -179,6 +179,9 @@ implements
     );
   }
 
+  /*
+    **IMPORTANT** note that in Titan 1.0.0 this method will iterate over **all** vertices and then *filter* those with label `vertexType._label()`.
+  */
   @Override
   public Stream<TitanVertex> vertices(AnyVertexType vertexType) {
 

--- a/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraph.java
@@ -180,7 +180,9 @@ implements
   }
 
   /*
-    **IMPORTANT** note that in Titan 1.0.0 this method will iterate over **all** vertices and then *filter* those with label `vertexType._label()`.
+    **IMPORTANT** note that in Titan 1.0.0 this method will iterate over **all** vertices and then *filter* those with label `vertexType._label()`. For a discussion see
+
+    - [Titan users post](https://groups.google.com/forum/#!topic/aureliusgraphs/f2HX9hUvBuA)
   */
   @Override
   public Stream<TitanVertex> vertices(AnyVertexType vertexType) {

--- a/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraphSchema.java
+++ b/src/main/java/com/bio4j/angulillos/titan/TitanUntypedGraphSchema.java
@@ -11,13 +11,10 @@ import com.thinkaurelius.titan.core.schema.*;
 public class TitanUntypedGraphSchema
 implements UntypedGraphSchema<TitanManagement> {
 
-  // TODO: create if not exists?
-
   /* This method should take into account vertex label */
   public TitanManagement createVertexType(TitanManagement titanManagement, AnyVertexType vertexType) {
     titanManagement
       .makeVertexLabel(vertexType._label())
-      // .setStatic() ?
       .make();
     return titanManagement;
   }
@@ -117,7 +114,4 @@ implements UntypedGraphSchema<TitanManagement> {
 
     return titanManagement;
   }
-
-
-
 }


### PR DESCRIPTION
In the case of titan, it will run over *all* graph vertices, irrespectively of their label, and *then* filter.

See https://groups.google.com/forum/#!topic/aureliusgraphs/f2HX9hUvBuA